### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/LLMOps/apps/fb_resource/src/node/helm_chart/node-activate/templates/node_active.yaml
+++ b/LLMOps/apps/fb_resource/src/node/helm_chart/node-activate/templates/node_active.yaml
@@ -9,7 +9,7 @@ spec:
       serviceAccountName: {{ .Values.namespace }}-clusteradmin-resource
       containers:
       - name: {{ .Values.name }}
-        image: docker.io/bitnamilegacy/kubectl:1.33.4-debian-12-r0
+        image: docker.io/soldevelo/kubectl:1.33.4-debian-12-r0
         securityContext:
           privileged: true
         command: ["/bin/bash", "-c", "--"]

--- a/LLMOps/devops/gaip_kafka/charts/zookeeper/values.yaml
+++ b/LLMOps/devops/gaip_kafka/charts/zookeeper/values.yaml
@@ -84,8 +84,8 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnamilegacy/zookeeper
-  tag: 3.9.2-debian-12-r2
+  repository: soldevelo/zookeeper
+  tag: 3.9.5-debian-12-r1
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/LLMOps/devops/gaip_kafka/values.yaml
+++ b/LLMOps/devops/gaip_kafka/values.yaml
@@ -87,8 +87,8 @@ diagnosticMode:
 ##
 image:
   registry: docker.io
-  repository: bitnamilegacy/kafka
-  tag: 3.7.0-debian-12-r6
+  repository: soldevelo/kafka
+  tag: 3.7.1-debian-12-r0
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'

--- a/LLMOps/devops/gaip_kong/charts/postgresql/values.yaml
+++ b/LLMOps/devops/gaip_kong/charts/postgresql/values.yaml
@@ -1206,8 +1206,8 @@ metrics:
   ##
   image:
     registry: docker.io
-    repository: bitnamilegacy/postgres-exporter
-    tag: 0.17.1-debian-12-r16
+    repository: soldevelo/postgres-exporter
+    tag: 0.17.1-debian-12-r0
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnamilegacy/kafka:3.7.0-debian-12-r6` → [`soldevelo/kafka:3.7.1-debian-12-r0`](https://hub.docker.com/r/soldevelo/kafka)
- `bitnamilegacy/postgres-exporter:0.17.1-debian-12-r16` → [`soldevelo/postgres-exporter:0.17.1-debian-12-r0`](https://hub.docker.com/r/soldevelo/postgres-exporter)
- `bitnamilegacy/zookeeper:3.9.2-debian-12-r2` → [`soldevelo/zookeeper:3.9.5-debian-12-r1`](https://hub.docker.com/r/soldevelo/zookeeper)
- `bitnamilegacy/kubectl:1.33.4-debian-12-r0` → [`soldevelo/kubectl:1.33.4-debian-12-r0`](https://hub.docker.com/r/soldevelo/kubectl)